### PR TITLE
Update messages.json for V1 en with very important questions

### DIFF
--- a/v1/src/_locales/en/messages.json
+++ b/v1/src/_locales/en/messages.json
@@ -63,9 +63,6 @@
   "label_9": {
     "message": "For 5 hours"
   },
-  "label_13": {
-    "message": "For a custom time period"
-  },
   "label_10": {
     "message": "Enable notifications"
   },
@@ -74,6 +71,9 @@
   },
   "label_12": {
     "message": "Open FAQs"
+  },
+  "label_13": {
+    "message": "For a custom time period"
   },
   "label_14": {
     "message": "Logged-in accounts"
@@ -215,19 +215,6 @@
   "options_notifications_15": {
     "message": "Default sound notification is"
   },
-  "options_notifications_31": {
-    "message": "Custom sound notification"
-  },
-  "options_notifications_32": {
-    "message": "name or email contains"
-  },
-  "options_notifications_33": {
-    "message": "email title contains"
-  },
-  "options_notifications_34": {
-    "message": "email summary contains"
-  },
-
   "options_notifications_16": {
     "message": "Gmail™ Notifier default alert"
   },
@@ -248,9 +235,6 @@
   },
   "options_notifications_22": {
     "message": "If your browser is not playing the custom notification sound, try to convert it into a plain WAV format using an online conversion tool."
-  },
-  "options_notifications_35": {
-    "message": "To select a new custom sound, select a built-in sound first and then change the option to custom sound"
   },
   "options_notifications_23": {
     "message": "Volume of the sound notification is"
@@ -275,6 +259,21 @@
   },
   "options_notifications_30": {
     "message": "Combine all concurrent desktop notifications into a single notification"
+  },
+  "options_notifications_31": {
+    "message": "Custom sound notification"
+  },
+  "options_notifications_32": {
+    "message": "name or email contains"
+  },
+  "options_notifications_33": {
+    "message": "email title contains"
+  },
+  "options_notifications_34": {
+    "message": "email summary contains"
+  },
+  "options_notifications_35": {
+    "message": "To select a new custom sound, select a built-in sound first and then change the option to custom sound"
   },
   "options_tab": {
     "message": "Tab Opening:"
@@ -378,9 +377,6 @@
   "options_misc_5": {
     "message": "Blue color for \"No Unread\" and gray color for \"Disconnected\""
   },
-  "options_misc_9": {
-    "message": "Red color for \"No Unread\" and gray color for \"Disconnected\""
-  },
   "options_misc_6": {
     "message": "Show desktop notification to warn that Gmail™ is already opened in the active tab"
   },
@@ -389,6 +385,9 @@
   },
   "options_misc_8": {
     "message": "Reset all settings back to factory"
+  },
+  "options_misc_9": {
+    "message": "Red color for \"No Unread\" and gray color for \"Disconnected\""
   },
   "options_misc_10": {
     "message": "Only fire desktop and sound notifications when email has arrived in less than (in minutes): "


### PR DESCRIPTION
Hello again

I noticed that the English files (en) of the V1, V2 and V3.Classic part state the elements in the same order or almost and that there are only a few subtle variations.

I also noticed that the French files (fr) (and also those of all the other languages) state the elements in the same order as the (en) file for the V2 and V3.classic part

However, for the V1 part the order is completely upset between (en) and the other languages ​​and it is very difficult to compare the languages ​​to check if all the terms have been translated correctly.

That is why I wanted to know if it is the English V1 part that is out of order or if it is all the languages ​​of V1 that need to be reviewed?

I can take care of putting the V1 file (fr) in the same order as the V1 file (en) but I am surprised that in the V1 part, only the (en) file is in a different order.

So I wonder if it would not be following a PR on the V1 file (en) that an error would have crept in.

I tried to put a little order in the (en) V1 file but it is possible that it is not judicious because there is perhaps an error in this file.

Thank you for the answer and again congratulations for this Firefox and Chrome extension that I can no longer do without.

Kind regards

P.S. for the V3.dev part I do not use it but I noticed that the translation into (fr) is not done and I could possibly take care of it if the need arose.